### PR TITLE
Fix CalendarView scroll to next month

### DIFF
--- a/qml/qmlcalendar/CalendarView.qml
+++ b/qml/qmlcalendar/CalendarView.qml
@@ -324,6 +324,7 @@ Item  {
                 MonthDaysGrid {
                     id: nextMonthDaysGrid
                     width: monthDaysGridFlickable.width
+                    height: parent.height
                 }
             }
         }


### PR DESCRIPTION
Next month was not visible while dragging due to the undefined height.

Hello,

I make a free adaptation of your component (I can only test in a desktop environment), and I find that when dragging to the right, the next month does not show until flick ended, because the next month delegate was not correctly defined. 
